### PR TITLE
#43 - Add tests for dryrun param in shell configurator

### DIFF
--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,8 +1,8 @@
 import os
+import sys
 from datetime import datetime, timedelta
 
 import pytest
-import six
 
 from unfurl.configurator import Status
 from unfurl.configurators.shell import ShellConfigurator, subprocess
@@ -40,7 +40,7 @@ class TestShellConfigurator:
 
         assert isinstance(err, subprocess.TimeoutExpired)
 
-    @pytest.mark.skipif(six.PY2, reason="requires Python 3")
+    @pytest.mark.skipif(sys.version_info < (3, 7, 5), reason="requires Python 3.7.5")
     def test_timeout_with_ensemble(self):
         runner = Runner(YamlManifest(ENSEMBLE_TIMEOUT))
         start_time = datetime.now()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,16 +1,15 @@
 import os
-from subprocess import TimeoutExpired
 
 import pytest
 
 from unfurl.configurator import Status
-from unfurl.configurators.shell import ShellConfigurator
+from unfurl.configurators.shell import ShellConfigurator, subprocess
 from unfurl.job import JobOptions, Runner
 from unfurl.yamlmanifest import YamlManifest
 
 
 class TestShellConfigurator:
-    def setUp(self):
+    def setup(self):
         path = os.path.join(
             os.path.dirname(__file__), "examples", "shell-ensemble.yaml"
         )
@@ -37,7 +36,7 @@ class TestShellConfigurator:
 
         err = configurator.runProcess(cmd="sleep 42", timeout=1)
 
-        assert isinstance(err, TimeoutExpired)
+        assert isinstance(err, subprocess.TimeoutExpired)
 
 
 class TestDryRun:

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -36,7 +36,7 @@ class TestShellConfigurator:
     def test_timeout(self):
         configurator = ShellConfigurator(None)
 
-        err = configurator.runProcess(cmd="sleep 15", timeout=1)
+        err = configurator.runProcess(cmd="sleep 5", timeout=1)
 
         assert isinstance(err, subprocess.TimeoutExpired)
 

--- a/unfurl/job.py
+++ b/unfurl/job.py
@@ -510,8 +510,8 @@ class Job(ConfigChange):
                     continue
 
                 if self.jobOptions.planOnly:
-                    errors = self.canRunTask(task)
-                    if errors:
+                    ok, errors = self.canRunTask(task)
+                    if not ok:
                         result = task.finished(
                             ConfiguratorResult(False, False, result=errors)
                         )
@@ -651,10 +651,10 @@ class Job(ConfigChange):
             can_run = False
 
         if can_run:
-            return False
+            return True, ""
         else:
             logger.info("could not run task %s: %s", task, reason)
-            return "could not run: " + reason
+            return False, "could not run: " + reason
 
     def shouldAbort(self, task):
         return False  # XXX3
@@ -668,8 +668,8 @@ class Job(ConfigChange):
         * Requests a resource with requested metadata, if it doesn't exist, a task is run to make it so
         (e.g. add a dns entry, install a package).
         """
-        errors = self.canRunTask(task)
-        if errors:
+        ok, errors = self.canRunTask(task)
+        if not ok:
             return task.finished(ConfiguratorResult(False, False, result=errors))
 
         task.start()

--- a/unfurl/job.py
+++ b/unfurl/job.py
@@ -487,7 +487,7 @@ class Job(ConfigChange):
                     continue
 
                 if self.jobOptions.planOnly:
-                    errors = self.cantRunTask(task)
+                    errors = self.canRunTask(task)
                     if errors:
                         result = task.finished(
                             ConfiguratorResult(False, False, result=errors)
@@ -579,7 +579,7 @@ class Job(ConfigChange):
             task.priority = priority
         return priority > Priority.ignore
 
-    def cantRunTask(self, task):
+    def canRunTask(self, task):
         """
         Checked at runtime right before each task is run
 
@@ -645,7 +645,7 @@ class Job(ConfigChange):
         * Requests a resource with requested metadata, if it doesn't exist, a task is run to make it so
         (e.g. add a dns entry, install a package).
         """
-        errors = self.cantRunTask(task)
+        errors = self.canRunTask(task)
         if errors:
             return task.finished(ConfiguratorResult(False, False, result=errors))
 


### PR DESCRIPTION
I used pytest's parametrize decorator to save bunch of lines of code. I had to also change `cantRunTask` to correctly return an error when task doesn't have `dryrun` input defined.

One more idea. I think we should not use negation in function name. Are you ok @aszs with renaming `cantRunTask` to `not canRunTask`?