### PR TITLE
#55 - Fix search in docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ deps =
   recommonmark
   sphinx-click>=2.5.0
   stevedore>=1.20.0
-  sphinxbootstrap4theme
+  git+https://github.com/jozo/sphinxbootstrap4theme
   sphinxcontrib-documentedlist
 ; -W turns warnings into errors
 commands = sphinx-build ./docs {toxworkdir}/docs/html -d {toxworkdir}/docs/doctrees --color -bhtml {posargs}


### PR DESCRIPTION
Use forked theme with the missing js file included

I needed to search in docs locally. This is just a quick fix. Last activity on the original theme repo is from 2 years ago. Docs generation shows ~100 warnings. => We should change the theme to something else.