### PR TITLE
#62 - Fix extras requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = unfurl
 summary = use Git to record and deploy changes to your DevOps infrastructure
-description-file = README.md
-description-content-type = text/markdown
+description_file = README.md
+description_content_type = text/markdown
 author = Adam Souzis
 author_email = adam@onecommons.org
-home-page = https://github.com/onecommons/unfurl
+home_page = https://github.com/onecommons/unfurl
 license = MIT
 classifier =
     Development Status :: 4 - Beta
@@ -19,6 +19,18 @@ classifier =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 # keywords =
+
+[extras]
+full =
+    ansible[azure]>=2.9.10,<2.10.0
+    boto
+    boto3
+    docker[tls]
+    google-auth
+    openshift
+    requests>=2.14.2
+    subprocess32:python_version<'3'
+    supervisor
 
 [bdist_wheel]
 # This flag says to generate wheels that support both Python 2 and Python

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,10 @@
 # Always prefer setuptools over distutils
 from setuptools import setup
 
-with open("full-requirements.txt") as f:
-    full_requirements = filter(
-        None, [line.partition("#")[0].strip() for line in f.read().splitlines()]
-    )
 
 setup(
     setup_requires=["pbr"],
     pbr=True,
     # XXX don't include .py files that haven't been committed to git
     include_package_data=True,
-    extras_require={"full": full_requirements},
 )


### PR DESCRIPTION
Move extras to setup.cfg

It looks like pbr doesn't work with extras_require in setup.py. Instead it should be defined in setup.cfg. This is just a quick fix.
https://docs.openstack.org/pbr/latest/user/using.html#extra-requirements

Also, I changed "-" to "_" in setup.cfg to fix warnings.