### PR TITLE
Add new filter for filtering numbers

### DIFF
--- a/unfurl/filter_plugins/ref.py
+++ b/unfurl/filter_plugins/ref.py
@@ -8,7 +8,7 @@ from unfurl.eval import Ref, mapValue
 from unfurl.support import abspath, getdir
 from unfurl.util import which
 
-NUMBERS = re.compile(r"\d+(?:\.\d+)?")
+NUMBERS = re.compile(r"[^\d.]")
 
 
 @contextfilter
@@ -44,15 +44,15 @@ def get_dir(context, relativeTo, mkdir=True):
     return getdir(refContext, relativeTo, mkdir)
 
 
-def only_number(string: str) -> str:
-    """Removes everything from the string except for the first number
+def only_numbers(string: str) -> str:
+    """Removes everything from the string except for digits and `.`
 
     Example: " 200.2 GB" -> "200.2"
     """
-    results = NUMBERS.findall(string)
-    if results:
-        return results[0]
-    raise ValueError("No numbers found in {}".format(string))
+    result = re.sub(NUMBERS, "", string)
+    if result:
+        return result
+    raise ValueError(f"No numbers found in '{string}'")
 
 
 class FilterModule(object):
@@ -64,5 +64,5 @@ class FilterModule(object):
             "abspath": _abspath,
             "get_dir": get_dir,
             "which": which,
-            "only_number": only_number,
+            "only_numbers": only_numbers,
         }

--- a/unfurl/filter_plugins/ref.py
+++ b/unfurl/filter_plugins/ref.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2020 Adam Souzis
 # SPDX-License-Identifier: MIT
-import os.path
+import re
+
+from jinja2.filters import contextfilter
+
 from unfurl.eval import Ref, mapValue
 from unfurl.support import abspath, getdir
 from unfurl.util import which
-from jinja2.filters import contextfilter
 
-# from ansible.errors import AnsibleError, AnsibleFilterError
+NUMBERS = re.compile(r"\d+(?:\.\d+)?")
 
 
 @contextfilter
@@ -42,6 +44,17 @@ def get_dir(context, relativeTo, mkdir=True):
     return getdir(refContext, relativeTo, mkdir)
 
 
+def only_number(string: str) -> str:
+    """Removes everything from the string except for the first number
+
+    Example: " 200.2 GB" -> "200.2"
+    """
+    results = NUMBERS.findall(string)
+    if results:
+        return results[0]
+    raise ValueError("No numbers found in {}".format(string))
+
+
 class FilterModule(object):
     def filters(self):
         return {
@@ -51,4 +64,5 @@ class FilterModule(object):
             "abspath": _abspath,
             "get_dir": get_dir,
             "which": which,
+            "only_number": only_number,
         }


### PR DESCRIPTION
I think jinja and ansible doesn't give us filter which could transform string from "200GB" to "200". This PR adds such filter. Not sure if `only_number` is best name for it. :thinking: 

Example how it will be used:
https://github.com/onecommons/unfurl-examples/commit/69509b709439d9fed92c1463d1405e7a364b87c7