### PR TITLE
#70 - Add log with error message when configator fails

### DIFF
--- a/unfurl/planrequests.py
+++ b/unfurl/planrequests.py
@@ -285,7 +285,8 @@ def _render_request(job, parent, req, future_requests):
     task.logger.debug("rendering %s %s", task.target.name, task.name)
     try:
         task.rendered = task.configurator.render(task)
-    except Exception:
+    except Exception as e:
+        logger.debug("Configurator failed: %s", e)
         if task._workFolder:
             task._workFolder.failed()
         task._inputs = None


### PR DESCRIPTION
Not it prints:

```
 UNFURL  DEBUG  Configurator failed: Could not load configurator _home_jozo_d_unfurl_examples_cloud_gcp_helpers_py.MetadataConfiguratora
 UNFURL  ERROR  configurator.render failed
```