### PR TITLE
#72 - Change warning logs color to support white bg in terminal

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # pbr uses this for install_requires
 pipenv>=2020.6.2 # MIT
-click>=7.1.2 # BSD 3-clause
+click>=8.0.1 # BSD 3-clause
 click-log  # MIT
 pyrsistent==0.15.7; python_version<'3' # last version with 2.7 support (needed for jsonschema)
 jsonschema[format_nongpl]==3.2 # MIT

--- a/unfurl/logs.py
+++ b/unfurl/logs.py
@@ -46,7 +46,7 @@ class ColorHandler(logging.StreamHandler):
     STYLE_LEVEL = {
         Levels.CRITICAL: {"bg": "bright_red", "fg": "white"},
         Levels.ERROR: {"bg": "red", "fg": "white"},
-        Levels.WARNING: {"bg": "bright_yellow", "fg": "white"},
+        Levels.WARNING: {"bg": (255, 126, 0), "fg": "white"},
         Levels.INFO: {"bg": "blue", "fg": "white"},
         Levels.VERBOSE: {"bg": "bright_blue", "fg": "white"},
         Levels.DEBUG: {"bg": "black", "fg": "white"},
@@ -55,7 +55,7 @@ class ColorHandler(logging.StreamHandler):
     STYLE_MESSAGE = {
         Levels.CRITICAL: {"fg": "bright_red"},
         Levels.ERROR: {"fg": "red"},
-        Levels.WARNING: {"fg": "bright_yellow"},
+        Levels.WARNING: {"fg": (255, 126, 0)},
         Levels.INFO: {"fg": "blue"},
         Levels.VERBOSE: {},
         Levels.DEBUG: {},


### PR DESCRIPTION
This is how it looks like on white bg:

![Screenshot from 2021-07-06 20-55-05](https://user-images.githubusercontent.com/4247916/124652522-82767d80-de9c-11eb-9fab-12442e440b07.png)
