### PR TITLE
Add container image with Podman for use in runner

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           name: DocumentationHTML
           path: .tox/docs/html/
+
   deploy_dockerhub:
     needs: test
     if: github.ref == 'refs/heads/master'
@@ -87,7 +88,7 @@ jobs:
         with:
           username: ${{ env.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKER_HUB }}
-      - name: fetch repo
+      - name: Fetch repo
         uses: actions/checkout@v2
         with:
           submodules: recursive
@@ -123,7 +124,61 @@ jobs:
             GCLOUD_VERSION=${{ env.GCLOUD_VERSION }}
             KOMPOSE_VERSION=${{ env.KOMPOSE_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
-  publish:
+
+  deploy_dockerhub_podman:
+    needs: deploy_dockerhub
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_USER: "ocbuilds"
+    # Map a step output to a job output
+    outputs:
+      release: ${{ steps.get_tag_name.outputs.release }}
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ env.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKER_HUB }}
+      - name: fetch repo
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Get the tag name or abbreviated commit digest
+        id: get_tag_name
+        run: |
+          label=$(git describe --contains --always)
+          echo "::set-output name=tag::"${label%^0}
+          if [[ $label =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,4}.0$ ]]; then
+              echo ::set-output name=release::true
+          fi
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            onecommons/unfurl
+          tags: |
+            type=raw,value=latest-podman,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+            type=raw,value=stable-podman,enable=${{ steps.get_tag_name.outputs.release || 'false' }}
+            type=raw,value=${{ steps.get_tag_name.outputs.tag }}-podman
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./docker/Dockerfile.podman
+          push: true
+          build-args: |
+            HELM_VERSION=${{ env.HELM_VERSION }}
+            TERRAFORM_VERSION=${{ env.TERRAFORM_VERSION }}
+            GCLOUD_VERSION=${{ env.GCLOUD_VERSION }}
+            KOMPOSE_VERSION=${{ env.KOMPOSE_VERSION }}
+            UNFURL_TAG=${{ steps.get_tag_name.outputs.tag }}
+          tags: ${{ steps.meta.outputs.tags }}
+
+  publish_pypi:
     needs: deploy_dockerhub
     if: needs.deploy_dockerhub.outputs.release
     runs-on: ubuntu-latest
@@ -141,6 +196,7 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI }}
           verbose: true
+
   docs:
     needs: deploy_dockerhub
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/publish-docs'

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -73,7 +73,7 @@ jobs:
           name: DocumentationHTML
           path: .tox/docs/html/
 
-  deploy_dockerhub:
+  publish_dockerhub:
     needs: test
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
@@ -125,15 +125,12 @@ jobs:
             KOMPOSE_VERSION=${{ env.KOMPOSE_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
 
-  deploy_dockerhub_podman:
-    needs: deploy_dockerhub
+  publish_dockerhub_podman:
+    needs: publish_dockerhub
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     env:
       DOCKERHUB_USER: "ocbuilds"
-    # Map a step output to a job output
-    outputs:
-      release: ${{ steps.get_tag_name.outputs.release }}
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -179,8 +176,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
   publish_pypi:
-    needs: deploy_dockerhub
-    if: needs.deploy_dockerhub.outputs.release
+    needs: publish_dockerhub
+    if: needs.publish_dockerhub.outputs.release
     runs-on: ubuntu-latest
     steps:
       - name: fetch repo
@@ -198,7 +195,7 @@ jobs:
           verbose: true
 
   docs:
-    needs: deploy_dockerhub
+    needs: publish_dockerhub
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/publish-docs'
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Simple, stand-alone CLI that can be used both in your local development environm
 
 ### Deploy infrastructure from simple, application-centric descriptions
 
-- Model your cloud infrasture with [OASIS TOSCA](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=tosca) (Topology and Orchestration Specification for Cloud Applications) standard YAML vocabulary.
+- Model your cloud infrastructure with [OASIS TOSCA](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=tosca) (Topology and Orchestration Specification for Cloud Applications) standard YAML vocabulary.
 - Import reusable and adaptable components or build (and publish) your own.
 - Easily declare dependencies to enable incremental deployment.
 - Path-based query DSL to express dynamic relationships between resources and configurations
@@ -91,7 +91,7 @@ Simple, stand-alone CLI that can be used both in your local development environm
 - Automatic encryption of files in `secrets` folders.
 - Sensitive content redacted in output and logs
 
-### “Day Two” Operations
+### "Day Two" Operations
 
 - Check, discover and repair commands
 - Define your own workflows for maintenance tasks like backup and restore.
@@ -100,27 +100,39 @@ Simple, stand-alone CLI that can be used both in your local development environm
 
 `unfurl` is available on [PyPI](https://pypi.org/project/unfurl/). You can install using `pip` (or `pip3`):
 
-`pip install unfurl`
+```
+pip install unfurl
+```
 
 By default `unfurl` creates a virtual Python environment to run in so it only installs the minimal requirements needed to run the command line. If you want to run it using your system Python install it with the "full" option:
 
-`pip install unfurl[full]`
+```
+pip install unfurl[full]
+```
 
 You can also install `unfurl` directly from this repository to get the latest code:
 
-`pip3 install "git+https://github.com/onecommons/unfurl.git#egg=unfurl"`
+```
+pip3 install "git+https://github.com/onecommons/unfurl.git#egg=unfurl"
+```
 
-Alternatively, you can use the Unfurl container on docker.io at `onecommons/unfurl:latest`
+Alternatively, you can use the [Unfurl container on Docker Hub](https://hub.docker.com/r/onecommons/unfurl):
+
+```
+docker run --rm -it -v $(pwd):/data -w /data onecommons/unfurl:stable unfurl ...
+```
+
+The `stable` tag matches the version published to PyPi; `latest` is the latest code from the repository.
 
 ## Requirements
 
-Linux or MacOs
+- Linux or MacOS
+- Git
+- Python (3.7, 3.8, 3.9 or 3.10)
 
-Python (3.7, 3.8, 3.9 or 3.10); git
+  > Python 3.6 is not tested automatically but should work. Make sure you have the latest version of pip installed (`pip install -U pip`), and may need Rust installed for the [cryptography library](https://github.com/pyca/cryptography/blob/main/docs/installation.rst).
 
-Python 3.6 is not tested automatically but should work. However you should make sure you have the latest version of pip installed (`pip install -U pip`) and may need to have Rust installed for the [crytography library](https://github.com/pyca/cryptography/blob/main/docs/installation.rst).
-
-Optional: docker
+- Optional: Docker
 
 ## Shell autocomplete
 
@@ -137,17 +149,23 @@ Use the table below to activate shell autocompletion for the `unfurl`:
 
 ## Developing
 
-`git clone --recurse-submodules https://github.com/onecommons/unfurl`
+```
+git clone --recurse-submodules https://github.com/onecommons/unfurl
+```
 
 To build documentation: Run `tox -e docs`.
 
 To build a distribution package run:
 
-`python setup.py sdist bdist_wheel`
+```
+python setup.py sdist bdist_wheel
+```
 
 You can now install this package with pip, for example:
 
-`pip install ./dist/unfurl-0.2.2.dev3-py2.py3-none-any.whl`
+```
+pip install ./dist/unfurl-0.2.2.dev3-py2.py3-none-any.whl
+```
 
 ## Running unit tests
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.9.9-slim
 
 RUN apt-get -qq update && \
-    apt-get install -qq -y git curl unzip wget expect && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get -qq install -y git curl unzip wget expect && \
+    apt-get -qq clean -y && rm -rf /var/lib/apt/lists/*
 
 ARG TERRAFORM_VERSION=1.1.4
 ARG HELM_VERSION=3.7.1
@@ -38,5 +38,5 @@ RUN echo "Installing Terraform" && \
 
 COPY . /unfurl
 
-RUN pip install /unfurl[full] && \
+RUN pip install --no-cache-dir /unfurl[full] && \
     rm -rf /unfurl

--- a/docker/Dockerfile.podman
+++ b/docker/Dockerfile.podman
@@ -1,0 +1,14 @@
+ARG  UNFURL_TAG=latest
+FROM onecommons/unfurl:${UNFURL_TAG}
+
+RUN apt-get -qq update && \
+    apt-get -qq install -y --no-install-recommends podman buildah && \
+    apt-get -qq clean -y && rm -rf /var/lib/apt/lists/*
+
+# add config to use host (outer container) namespaces and such
+# taken from https://github.com/containers/podman/tree/main/contrib/podmanimage
+ADD https://raw.githubusercontent.com/containers/libpod/master/contrib/podmanimage/stable/containers.conf \
+    /etc/containers/containers.conf
+
+# emulate docker behavior and pull from docker registry if no host given
+RUN echo 'unqualified-search-registries=["docker.io"]' > /etc/containers/registries.conf

--- a/docker/Dockerfile.podman
+++ b/docker/Dockerfile.podman
@@ -6,6 +6,10 @@ RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends podman buildah && \
     apt-get -qq clean -y && rm -rf /var/lib/apt/lists/*
 
+# add alias script like podman-docker (which is not available in debian currently)
+RUN echo -e '#!/bin/sh\nexec /usr/bin/podman $@' > /usr/local/bin/docker && \
+    chmod +x /usr/local/bin/docker
+
 # add config to use host (outer container) namespaces and such
 # taken from https://github.com/containers/podman/tree/main/contrib/podmanimage
 ADD https://raw.githubusercontent.com/containers/libpod/master/contrib/podmanimage/stable/containers.conf \

--- a/docker/Dockerfile.podman
+++ b/docker/Dockerfile.podman
@@ -1,3 +1,4 @@
+# use tag param to reuse the just-built image in CI
 ARG  UNFURL_TAG=latest
 FROM onecommons/unfurl:${UNFURL_TAG}
 


### PR DESCRIPTION
This PR adds a new container build that includes [Podman](https://podman.io) for container-in-container use. Podman does not require a daemon and as such is easier to manage inside an exising container.

The new image builds off the existing `onecommons/unfurl` image, and follows the existing tagging scheme (`latest` / `stable` / TAG), with a `-podman` suffix (`latest-podman` / `stable-podman` / TAG`-podman`)

Also includes a slimming of the exising image by ~200MB by clearing the `pip` cache, and typo fixes in the README and an example on using the Docker image. 

Resolves onecommons/gitlab-oc#968.
