### PR TITLE
Fix absolute path check in export

### DIFF
--- a/unfurl/localenv.py
+++ b/unfurl/localenv.py
@@ -235,6 +235,12 @@ class Project:
         return None
 
     def get_relative_path(self, path: str) -> str:
+        # TODO: consider asserting that `path` is an absolute path so this method is not ambiguous
+        # assert os.path.isabs(path)
+        # return os.path.relpath(path, self.projectRoot)
+
+        # NOTE: `os.path.abspath` constructs the absolute path from the current working directory
+        # This may not be the desired behavior (unfurl-server being a counterexample)
         return os.path.relpath(os.path.abspath(path), self.projectRoot)
 
     def is_path_in_project(self, path: str) -> bool:

--- a/unfurl/to_json.py
+++ b/unfurl/to_json.py
@@ -1452,7 +1452,7 @@ def set_deploymentpaths(project, existing=None):
         if "environment" in ensemble_info and "project" not in ensemble_info:
             # exclude external ensembles
             path = os.path.dirname(ensemble_info["file"])
-            if os.path.abspath(path):
+            if os.path.isabs(path):
                 path = project.get_relative_path(path)
             obj = {
                 "__typename": "DeploymentPath",


### PR DESCRIPTION
~~This solves a bug that was introduced recently where unfurl-server would record a path relative to the current working directory.~~

~~I changed `get_relative_path` to check whether the provided path is absolute, relative to the CWD, relative to the project root, or not found.  It will return a path relative to the project path or `None` if the specified `path` does not exist.~~