### PR TITLE
container: fix shebang in generated docker shim

### DIFF
--- a/docker/Dockerfile.podman
+++ b/docker/Dockerfile.podman
@@ -7,7 +7,7 @@ RUN apt-get -qq update && \
     apt-get -qq clean -y && rm -rf /var/lib/apt/lists/*
 
 # add alias script like podman-docker (which is not available in debian currently)
-RUN echo -e '#!/bin/sh\nexec /usr/bin/podman $@' > /usr/local/bin/docker && \
+RUN echo '#!/bin/sh\nexec /usr/bin/podman $@' > /usr/local/bin/docker && \
     chmod +x /usr/local/bin/docker
 
 # add config to use host (outer container) namespaces and such


### PR DESCRIPTION
`echo -e` is supposed to interpret escape sequences e.g. the `\n` in the echoed string, but is being interpreted as a literal and breaks the shebang.

```console
$ docker run --rm onecommons/unfurl:43ffcf5-podman sh -c 'cat $(which docker)'
-e #!/bin/sh
exec /usr/bin/podman $@
```

Echo without `-e` is interpreting the newline anyway, so it can be removed.