### PR TITLE
Serve nginx stale cache on 500 error

### DIFF
--- a/docker/aux/nginx.conf
+++ b/docker/aux/nginx.conf
@@ -40,7 +40,7 @@ http {
       proxy_cache_revalidate on; # use conditional GET with if-modified-since
       #proxy_cache_min_uses 3; # min request count before cache starts
 
-      proxy_cache_use_stale error timeout updating;
+      proxy_cache_use_stale error timeout updating http_500;
 
       add_header X-Cache-Status $upstream_cache_status;
 


### PR DESCRIPTION
What we expected the `error` directive to do.
